### PR TITLE
Fix error when loading draft

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+1.1.8 2017-03-07
+  * Fix error when trying to load draft
+
 1.1.7 2016-12-14
   * Updating select2 assets (css/js) from 3.4.8 to 4.0.3
 

--- a/app/views/tenon/item_versions/index.html.haml
+++ b/app/views/tenon/item_versions/index.html.haml
@@ -1,4 +1,5 @@
-.modal-body= t('tenon.item_versions.choose_a_draft')
+.modal-body
+  = t('tenon.item_versions.choose_a_draft')
 
   .asset-list-scroller
     %ul.record-list#item_versions{data: {records: {url: item_versions_path(format: 'json', item_type: params[:item_type], item_id: params[:item_id]), template: 'tenon/templates/item_versions/item_version_row', name: 'item_version'}}}

--- a/lib/tenon/version.rb
+++ b/lib/tenon/version.rb
@@ -1,3 +1,3 @@
 module Tenon
-  VERSION = '1.1.7'
+  VERSION = '1.1.8'
 end


### PR DESCRIPTION
When trying to load a draft (page, for example) the loading gear spins because of an error when trying to load the broken draft view from the server.